### PR TITLE
Add support for creating asynchronously-provisioned services

### DIFF
--- a/create-services-plugin.go
+++ b/create-services-plugin.go
@@ -153,8 +153,7 @@ func (c *CreateServicePush) createService(name, broker, plan, JSONParam string) 
 
 		if service.LastOperation.State == "succeeded" {
 			break
-		}
-		if service.LastOperation.State == "failed" {
+		} else if service.LastOperation.State == "failed" {
 			return fmt.Errorf(
 				"error %s [status: %s]",
 				service.LastOperation.Description,

--- a/progress_spinner.go
+++ b/progress_spinner.go
@@ -8,12 +8,11 @@ import (
 type ProgressSpinner struct {
 	state                string
 	loadingMessage       string
-	updateLoadingMessage bool
 	writer               io.Writer
 }
 
 func NewProgressSpinner(writer io.Writer) *ProgressSpinner {
-	ipb := &ProgressSpinner{"|", "", true,writer}
+	ipb := &ProgressSpinner{"|", "", writer}
 	return ipb
 }
 func (ps *ProgressSpinner) Next(loadingMessage string) {
@@ -34,14 +33,6 @@ func (ps *ProgressSpinner) Next(loadingMessage string) {
 	ps.state = nextState
 	if loadingMessage != ps.loadingMessage {
 		ps.loadingMessage = loadingMessage
-		ps.updateLoadingMessage = true
-	} else {
-		ps.updateLoadingMessage = false
-	}
-	ps.write()
-}
-func (ps *ProgressSpinner) write() {
-	if ps.updateLoadingMessage {
 		fmt.Fprint(ps.writer, ps.loadingMessage+"\n")
 	}
 	fmt.Fprint(ps.writer, ps.state+"\r")

--- a/progress_spinner.go
+++ b/progress_spinner.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+type ProgressSpinner struct {
+	state                string
+	loadingMessage       string
+	updateLoadingMessage bool
+	writer               io.Writer
+}
+
+func NewProgressSpinner(writer io.Writer) *ProgressSpinner {
+	ipb := &ProgressSpinner{"|", "", true,writer}
+	return ipb
+}
+func (ps *ProgressSpinner) Next(loadingMessage string) {
+	var nextState string
+	switch ps.state {
+	case "|":
+		nextState = "/"
+		break
+	case "/":
+		nextState = "-"
+		break
+	case "-":
+		nextState = "\\"
+		break
+	default:
+		nextState = "|"
+	}
+	ps.state = nextState
+	if loadingMessage != ps.loadingMessage {
+		ps.loadingMessage = loadingMessage
+		ps.updateLoadingMessage = true
+	} else {
+		ps.updateLoadingMessage = false
+	}
+	ps.write()
+}
+func (ps *ProgressSpinner) write() {
+	if ps.updateLoadingMessage {
+		fmt.Fprint(ps.writer, ps.loadingMessage+"\n")
+	}
+	fmt.Fprint(ps.writer, ps.state+"\r")
+}


### PR DESCRIPTION
Took a crack at it.  I tested this with a manifest that contained both an asynchronously-provisioned service and a synchronously-provisioned service, as well as a service with a configuration guaranteed to fail (to test error reporting).  It works, but I'm just dabbling in Go, so please correct anything you feel is amiss.

Here's some example output:

```
Found ManifestFile: services-manifest.yml
bp-rds-async will now be created.
Now Running CLI Command: create-service hsdp-rds postgres-micro-dev bp-rds-async -c {"DBName": "testdb"}
Creating service instance bp-rds-async in org system / space service-brokers as bpandola...
OK

Create in progress. Use 'cf services' or 'cf service bp-rds-async' to check operation status.
RDS Instance is currently in the creating state.
RDS Instance is currently in the backing-up state.
Provision is complete.
bp-s3-sync will now be created.
Now Running CLI Command: create-service hsdp-s3 s3_bucket bp-s3-sync
Creating service instance bp-s3-sync in org system / space service-brokers as bpandola...
OK
```

Fixes #1